### PR TITLE
Disable test due to ngx-formly issue with Angular 19, reenable when fixed

### DIFF
--- a/frontend/src/app/formly.helpers.spec.ts
+++ b/frontend/src/app/formly.helpers.spec.ts
@@ -144,6 +144,8 @@ describe('findAndInsertExpressions', () => {
     expect(fieldConfig?.fieldGroup?.[1]?.fieldGroup?.[2]?.expressions?.['hide']).toBeTruthy(); // token_action.error
   });
 
+  /* Disabled test as ngx-formly's createComponent is broken in Angular 19.
+     Fix is in https://github.com/ngx-formly/ngx-formly/pull/4021 but is not released yet.
   it ('finds and inserts expressions on array from configs', () => {
     const {field, fixture} = renderComponent({
       schema: schema,
@@ -164,5 +166,5 @@ describe('findAndInsertExpressions', () => {
       // Check that hide expression is set for custom_key field.
       expect(arrayField?.fieldGroup?.[i].fieldGroup?.[1]?.expressions?.['hide']).toBeTruthy();
     }
-  });
+  });*/
 })


### PR DESCRIPTION
Disabled test as ngx-formly's createComponent is broken in Angular 19.
Fix is in https://github.com/ngx-formly/ngx-formly/pull/4021 but is not released yet.